### PR TITLE
fix eigen link

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Datasets
 Linear Algebra & Geometry
 -------------------------
 
-- [Eigen](eigen.tuxfamily.org) - Eigen is a C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.
+- [Eigen](http://eigen.tuxfamily.org) - Eigen is a C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.
 - [Boost.QVM](https://github.com/boostorg/qvm) - Quaternions, Vectors, Matrices library for Boost.
 - [Boost.Geometry](https://github.com/boostorg/geometry/) - Boost.Geometry contains instantiable geometry classes, but library users can also use their own.
 - [SpaceVecAlg](https://github.com/jrl-umi3218/SpaceVecAlg) - Implementation of spatial vector algebra for 3D geometry with the Eigen3 linear algebra library.


### PR DESCRIPTION
currently the eigen link takes me to https://github.com/ahundt/awesome-robotics/blob/master/eigen.tuxfamily.org , I guess because the link is not prefaced with http:// , so fixing that