### PR TITLE
Add wavemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Simultaneous Localization and Mapping (SLAM)
 - [co-fusion](https://github.com/martinruenz/co-fusion) - Real-time Segmentation, Tracking and Fusion of Multiple Objects. Extends ElasticFusion.
 - [Google Cartographer](https://github.com/googlecartographer/cartographer/) - Cartographer is a system that provides real-time simultaneous localization and mapping (SLAM) in 2D and 3D across multiple platforms and sensor configurations.
 - [OctoMap](https://github.com/OctoMap/octomap) - An Efficient Probabilistic 3D Mapping Framework Based on Octrees. Contains the main OctoMap library, the viewer octovis, and dynamicEDT3D.
-- [ORB_SLAM2](https://github.com/raulmur/ORB_SLAM2) - Real-Time SLAM for Monocular, Stereo and RGB-D Cameras, with Loop Detection and Relocalization Capabilities.
+- [wavemap](https://github.com/ethz-asl/wavemap) - Fast, efficient and accurate multi-resolution, multi-sensor 3D occupancy mapping.
 
 
 # License


### PR DESCRIPTION
This pull request proposes to add [wavemap](https://github.com/ethz-asl/wavemap) to the list of SLAM packages.
The library performs multi-resolution occupancy mapping in a similar fashion to OctoMap while being more memory efficient thanks to wavelet compression and orders of magnitude faster thanks to a coarse-to-fine measurement integration scheme, multi-threading, and advanced data structures. Compared to our previous work, voxblox, wavemap achieves higher memory efficiency and recall while being equally fast for LiDARs and up to an order of magnitude faster for depth cameras.